### PR TITLE
feat: RDS PostgreSQLモジュールを実装 (#2)

### DIFF
--- a/app/infra/modules/rds/README.md
+++ b/app/infra/modules/rds/README.md
@@ -1,0 +1,243 @@
+# RDS PostgreSQL Module
+
+Amazon RDS for PostgreSQL を構築するための Terraform モジュールです。
+
+## 機能
+
+- RDS PostgreSQL インスタンスの作成
+- プライベートサブネットへの配置
+- セキュリティグループの自動構成
+- Secrets Manager による認証情報管理
+- 自動バックアップとスナップショット
+- CloudWatch Logs 統合
+- 日本語対応（UTF8、Asia/Tokyo）
+
+## 必須変数
+
+| 変数名 | 型 | 説明 |
+|--------|-----|------|
+| `project` | string | プロジェクト名 |
+| `environment` | string | 環境名（`dev` または `prod`） |
+| `vpc_id` | string | VPC ID |
+| `private_subnet_ids` | list(string) | RDS を配置するプライベートサブネット ID のリスト |
+
+## オプション変数（主要なもの）
+
+| 変数名 | デフォルト値 | 説明 |
+|--------|-------------|------|
+| `db_name` | `"zousho"` | データベース名 |
+| `db_username` | `"postgres"` | マスターユーザー名 |
+| `instance_class` | `"db.t3.micro"` | RDS インスタンスクラス |
+| `allocated_storage` | `20` | 初期ストレージ容量（GB） |
+| `multi_az` | `false` | Multi-AZ 構成の有効化 |
+| `deletion_protection` | `true` | 削除保護の有効化 |
+| `skip_final_snapshot` | `false` | 削除時の最終スナップショットスキップ |
+| `lambda_security_group_id` | `""` | Lambda セキュリティグループ ID（接続許可用） |
+| `codebuild_security_group_id` | `""` | CodeBuild セキュリティグループ ID（接続許可用） |
+
+完全な変数リストは [variables.tf](./variables.tf) を参照してください。
+
+## 出力値
+
+| 出力名 | 説明 |
+|--------|------|
+| `db_instance_id` | RDS インスタンス ID |
+| `db_instance_endpoint` | RDS エンドポイント（ホスト名:ポート） |
+| `db_instance_address` | RDS ホスト名 |
+| `db_instance_port` | RDS ポート番号 |
+| `rds_security_group_id` | RDS セキュリティグループ ID |
+| `secret_arn` | Secrets Manager シークレット ARN |
+| `secret_name` | Secrets Manager シークレット名 |
+
+## 使用例
+
+### 基本的な使用方法
+
+```hcl
+module "rds" {
+  source = "../../modules/rds"
+
+  project     = "zousho"
+  environment = "dev"
+
+  vpc_id              = module.vpc.vpc_id
+  private_subnet_ids  = module.vpc.private_subnet_ids
+}
+```
+
+### dev 環境（推奨設定）
+
+```hcl
+module "rds" {
+  source = "../../modules/rds"
+
+  project     = "zousho"
+  environment = "dev"
+
+  vpc_id              = module.vpc.vpc_id
+  private_subnet_ids  = module.vpc.private_subnet_ids
+
+  # dev 環境向け設定
+  instance_class       = "db.t3.micro"
+  allocated_storage    = 20
+  multi_az             = false
+  deletion_protection  = false  # terraform destroy を許可
+  skip_final_snapshot  = true   # 削除時にスナップショット不要
+
+  # 詳細なログ出力
+  log_statement = "all"
+
+  # Lambda からの接続許可（モジュール作成後）
+  # lambda_security_group_id = module.lambda.security_group_id
+}
+```
+
+### prod 環境（推奨設定）
+
+```hcl
+module "rds" {
+  source = "../../modules/rds"
+
+  project     = "zousho"
+  environment = "prod"
+
+  vpc_id              = module.vpc.vpc_id
+  private_subnet_ids  = module.vpc.private_subnet_ids
+
+  # prod 環境向け設定
+  instance_class       = "db.t3.small"      # より高性能なインスタンス
+  allocated_storage    = 100
+  max_allocated_storage = 500               # 自動スケーリング上限
+  multi_az             = true                # 高可用性構成（予算に応じて）
+  deletion_protection  = true                # 誤削除防止
+  skip_final_snapshot  = false               # 削除時にスナップショット作成
+
+  backup_retention_period = 30              # 30日間バックアップ保持
+
+  # DDL のみログ出力（パフォーマンス考慮）
+  log_statement = "ddl"
+
+  # Performance Insights 有効化
+  performance_insights_enabled = true
+
+  # Lambda からの接続許可
+  lambda_security_group_id = module.lambda.security_group_id
+
+  # CodeBuild（DBマイグレーション）からの接続許可
+  codebuild_security_group_id = module.codebuild.security_group_id
+}
+```
+
+詳細な例は [examples/](./examples/) ディレクトリを参照してください。
+
+## セキュリティ
+
+### ネットワークセキュリティ
+
+- RDS は**プライベートサブネット**に配置されます
+- パブリックアクセスは**無効化**されます
+- Lambda/CodeBuild からのアクセスのみセキュリティグループで許可されます
+
+### データ暗号化
+
+- ストレージ暗号化が有効化されます（AWS 管理キー使用）
+- 必要に応じてカスタマーマネージドキー（KMS）への変更も可能です
+
+### 認証情報管理
+
+- マスターパスワードは 32 文字のランダム文字列で自動生成されます
+- 認証情報は AWS Secrets Manager に保存されます
+- Secrets Manager のシークレット名: `{project}/{environment}/rds/credentials`
+
+### 接続情報の取得
+
+Lambda 関数などから接続情報を取得する例：
+
+```python
+import boto3
+import json
+
+def get_db_credentials(secret_name):
+    client = boto3.client('secretsmanager')
+    response = client.get_secret_value(SecretId=secret_name)
+    return json.loads(response['SecretString'])
+
+# 使用例
+credentials = get_db_credentials('zousho/prod/rds/credentials')
+connection_string = credentials['connection_string']
+# postgresql://postgres:xxxxx@host:5432/zousho
+```
+
+## バックアップとリカバリ
+
+### 自動バックアップ
+
+- デフォルトで 7 日間の自動バックアップが有効
+- バックアップウィンドウ: 18:00-19:00 UTC（JST 03:00-04:00）
+- メンテナンスウィンドウ: 日曜 19:00-20:00 UTC（JST 日曜 04:00-05:00）
+
+### 最終スナップショット
+
+- `skip_final_snapshot = false` の場合、削除時に最終スナップショットを作成
+- スナップショット名: `{project}-{environment}-db-final-snapshot-{timestamp}`
+- **prod 環境では必ず `false` を設定してください**
+
+## モニタリング
+
+### CloudWatch Logs
+
+以下のログが CloudWatch Logs にエクスポートされます：
+
+- PostgreSQL ログ
+- アップグレードログ
+
+### Performance Insights
+
+- `performance_insights_enabled = true` で有効化
+- クエリパフォーマンスの詳細分析が可能
+- **prod 環境での有効化を推奨**
+
+### 拡張モニタリング
+
+現在は未サポートですが、必要に応じて追加可能です。
+
+## トラブルシューティング
+
+### Lambda から RDS に接続できない
+
+1. Lambda が VPC 内に配置されているか確認
+2. `lambda_security_group_id` が正しく設定されているか確認
+3. RDS と Lambda が同じ VPC 内にあるか確認
+
+### terraform destroy が失敗する
+
+`deletion_protection = true` の場合、削除保護が有効です：
+
+```hcl
+# 一時的に削除保護を無効化
+deletion_protection = false
+```
+
+適用後、再度 `terraform destroy` を実行してください。
+
+## 制限事項
+
+- PostgreSQL のみサポート（MySQL などは未サポート）
+- シングルリージョン構成（クロスリージョンレプリカは未サポート）
+- Read Replica の自動構成は未サポート
+
+## バージョン要件
+
+- Terraform >= 1.0
+- AWS Provider ~> 6.0
+- Random Provider ~> 3.6
+
+## ライセンス
+
+このモジュールは蔵書管理システムの一部です。
+
+## 参考資料
+
+- [Amazon RDS for PostgreSQL ドキュメント](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/)
+- [Terraform AWS Provider - RDS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance)
+- [プロジェクトアーキテクチャ](../../../../docs/system-architecture.md)

--- a/app/infra/modules/rds/examples/README.md
+++ b/app/infra/modules/rds/examples/README.md
@@ -1,0 +1,213 @@
+# RDS Module - 使用例
+
+このディレクトリには、RDS モジュールの環境別使用例が含まれています。
+
+## ディレクトリ構成
+
+```
+examples/
+├── README.md     # このファイル
+├── dev/          # 開発環境向け設定例
+│   └── main.tf
+└── prod/         # 本番環境向け設定例
+    └── main.tf
+```
+
+## 開発環境（dev）
+
+[dev/main.tf](./dev/main.tf)
+
+### 特徴
+
+- **コスト最適化**: 最小インスタンス（db.t3.micro）、シングル AZ 構成
+- **開発効率**: 削除保護なし、最終スナップショット不要
+- **デバッグ**: すべての SQL 文をログ出力
+- **バックアップ**: 1日間のみ保持
+
+### 推奨用途
+
+- ローカル開発環境
+- CI/CD テスト環境
+- 機能検証環境
+
+### 月額コスト目安
+
+- RDS (db.t3.micro): 約 $15-20/月
+- ストレージ (20GB): 約 $2-3/月
+- バックアップ (1日): ほぼ無料
+
+**合計: 約 $20-25/月**
+
+## 本番環境（prod）
+
+[prod/main.tf](./prod/main.tf)
+
+### 特徴
+
+- **高可用性**: より高性能なインスタンス（db.t3.small）、Multi-AZ 対応可能
+- **信頼性**: 削除保護有効、30日間バックアップ保持
+- **パフォーマンス**: Performance Insights 有効
+- **セキュリティ**: DDL のみログ出力（パフォーマンス考慮）
+- **スケーラビリティ**: 自動ストレージスケーリング（最大 500GB）
+
+### 推奨用途
+
+- 本番環境
+- ステージング環境
+
+### 月額コスト目安
+
+**シングル AZ 構成の場合:**
+- RDS (db.t3.small): 約 $30-40/月
+- ストレージ (100GB): 約 $10-15/月
+- バックアップ (30日): 約 $5-10/月
+- Performance Insights: 無料（7日間保持の場合）
+
+**合計: 約 $50-70/月**
+
+**Multi-AZ 構成の場合:**
+- RDS (db.t3.small Multi-AZ): 約 $70-80/月
+- その他同様
+
+**合計: 約 $90-110/月**
+
+> **注意**: Multi-AZ はコストが約2倍になりますが、高可用性が必要な場合に推奨されます。
+
+## 使い方
+
+### 1. VPC モジュールの準備
+
+まず VPC モジュールが作成されている必要があります。
+
+```bash
+cd ../../vpc
+terraform init
+terraform apply
+```
+
+### 2. 例のコピーと編集
+
+使用したい環境の例をコピーします。
+
+```bash
+# 開発環境の場合
+cp examples/dev/main.tf ../../environments/dev/rds.tf
+
+# 本番環境の場合
+cp examples/prod/main.tf ../../environments/prod/rds.tf
+```
+
+### 3. VPC との統合
+
+コメントアウトされている VPC モジュールの参照を有効化します。
+
+```hcl
+# コメントを解除
+module "vpc" {
+  source = "../../vpc"
+  # ...
+}
+
+module "rds" {
+  source = "../.."
+
+  # VPC の出力値を使用
+  vpc_id             = module.vpc.vpc_id
+  private_subnet_ids = module.vpc.private_subnet_ids
+
+  # ...
+}
+```
+
+### 4. Lambda/CodeBuild との統合
+
+Lambda や CodeBuild モジュールが作成されたら、セキュリティグループの設定を有効化します。
+
+```hcl
+module "rds" {
+  # ...
+
+  # コメントを解除
+  lambda_security_group_id    = module.lambda.security_group_id
+  codebuild_security_group_id = module.codebuild.security_group_id
+}
+```
+
+### 5. デプロイ
+
+```bash
+cd ../../environments/dev  # または prod
+
+terraform init
+terraform plan
+terraform apply
+```
+
+## 環境別の主な違い
+
+| 設定項目 | dev | prod |
+|---------|-----|------|
+| インスタンスクラス | db.t3.micro | db.t3.small |
+| ストレージ | 20GB | 100GB（最大500GB） |
+| Multi-AZ | false | false（必要に応じてtrue） |
+| 削除保護 | false | true |
+| 最終スナップショット | スキップ | 作成 |
+| バックアップ保持 | 1日 | 30日 |
+| ログレベル | all | ddl |
+| Performance Insights | 無効 | 有効 |
+| 月額コスト | $20-25 | $50-110 |
+
+## よくある質問
+
+### Q: dev 環境で削除できない
+
+A: `deletion_protection = true` になっている可能性があります。以下の手順で削除できます。
+
+```hcl
+# 1. 削除保護を無効化
+deletion_protection = false
+```
+
+```bash
+# 2. 適用
+terraform apply
+
+# 3. 削除
+terraform destroy
+```
+
+### Q: 接続情報はどこにありますか？
+
+A: AWS Secrets Manager に保存されています。
+
+```bash
+# AWS CLI で確認
+aws secretsmanager get-secret-value \
+  --secret-id zousho/dev/rds/credentials \
+  --query SecretString \
+  --output text | jq .
+```
+
+### Q: Multi-AZ は有効にすべきですか？
+
+A: 本番環境で高可用性が必要な場合は有効化を推奨しますが、コストが約2倍になります。小規模システムやステージング環境では無効でも問題ありません。
+
+### Q: Performance Insights は必要ですか？
+
+A: 本番環境では有効化を推奨します。クエリのパフォーマンス分析に役立ちます。7日間保持であれば追加コストはかかりません。
+
+### Q: バックアップから復元するには？
+
+A: AWS CLI または AWS マネジメントコンソールから復元できます。
+
+```bash
+aws rds restore-db-instance-from-db-snapshot \
+  --db-instance-identifier zousho-dev-db-restored \
+  --db-snapshot-identifier <snapshot-id>
+```
+
+## 参考資料
+
+- [モジュールドキュメント](../README.md)
+- [Amazon RDS 料金](https://aws.amazon.com/jp/rds/postgresql/pricing/)
+- [RDS ベストプラクティス](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_BestPractices.html)

--- a/app/infra/modules/rds/examples/dev/main.tf
+++ b/app/infra/modules/rds/examples/dev/main.tf
@@ -1,0 +1,126 @@
+# -----------------------------------------------------------------------------
+# RDS Module - Development Environment Example
+# -----------------------------------------------------------------------------
+# この例は開発環境向けの推奨設定を示しています。
+# コスト最適化とイテレーション速度を優先した構成です。
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+
+  default_tags {
+    tags = {
+      Environment = "dev"
+      Project     = "zousho"
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# VPC Module（例として記載）
+# 実際には既存の VPC モジュールを使用してください
+# -----------------------------------------------------------------------------
+# module "vpc" {
+#   source = "../../vpc"
+#
+#   project     = "zousho"
+#   environment = "dev"
+#   vpc_cidr    = "10.0.0.0/16"
+# }
+
+# -----------------------------------------------------------------------------
+# RDS Module - Dev Configuration
+# -----------------------------------------------------------------------------
+module "rds" {
+  source = "../.."
+
+  project     = "zousho"
+  environment = "dev"
+
+  # ネットワーク設定
+  # vpc_id             = module.vpc.vpc_id
+  # private_subnet_ids = module.vpc.private_subnet_ids
+
+  # データベース設定
+  db_name     = "zousho"
+  db_username = "postgres"
+  db_port     = 5432
+
+  # インスタンス設定（コスト最適化）
+  instance_class    = "db.t3.micro" # 最小インスタンス
+  allocated_storage = 20            # 最小ストレージ
+  multi_az          = false         # シングル AZ でコスト削減
+
+  # 削除設定（開発環境向け）
+  deletion_protection = false # terraform destroy を許可
+  skip_final_snapshot = true  # 削除時にスナップショット不要
+
+  # バックアップ設定（最小限）
+  backup_retention_period = 1 # 1日間のみ保持
+
+  # ログ設定（詳細なデバッグ情報）
+  log_statement = "all" # すべての SQL 文をログ出力
+
+  # モニタリング設定
+  performance_insights_enabled    = false # コスト削減のため無効
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+
+  # セキュリティグループ設定
+  # Lambda モジュール作成後に設定
+  # lambda_security_group_id = module.lambda.security_group_id
+
+  # CodeBuild モジュール作成後に設定
+  # codebuild_security_group_id = module.codebuild.security_group_id
+}
+
+# -----------------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------------
+output "db_endpoint" {
+  description = "RDS エンドポイント"
+  value       = module.rds.db_instance_endpoint
+}
+
+output "db_address" {
+  description = "RDS ホスト名"
+  value       = module.rds.db_instance_address
+}
+
+output "secret_name" {
+  description = "Secrets Manager シークレット名"
+  value       = module.rds.secret_name
+}
+
+output "rds_security_group_id" {
+  description = "RDS セキュリティグループ ID"
+  value       = module.rds.rds_security_group_id
+}
+
+# -----------------------------------------------------------------------------
+# 接続情報の確認方法
+# -----------------------------------------------------------------------------
+# AWS CLI で接続情報を取得:
+#
+# aws secretsmanager get-secret-value \
+#   --secret-id zousho/dev/rds/credentials \
+#   --query SecretString \
+#   --output text | jq .
+#
+# 接続文字列を取得:
+#
+# aws secretsmanager get-secret-value \
+#   --secret-id zousho/dev/rds/credentials \
+#   --query SecretString \
+#   --output text | jq -r .connection_string

--- a/app/infra/modules/rds/examples/prod/main.tf
+++ b/app/infra/modules/rds/examples/prod/main.tf
@@ -1,0 +1,177 @@
+# -----------------------------------------------------------------------------
+# RDS Module - Production Environment Example
+# -----------------------------------------------------------------------------
+# この例は本番環境向けの推奨設定を示しています。
+# 可用性、信頼性、セキュリティを優先した構成です。
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+
+  default_tags {
+    tags = {
+      Environment = "prod"
+      Project     = "zousho"
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# VPC Module（例として記載）
+# 実際には既存の VPC モジュールを使用してください
+# -----------------------------------------------------------------------------
+# module "vpc" {
+#   source = "../../vpc"
+#
+#   project     = "zousho"
+#   environment = "prod"
+#   vpc_cidr    = "10.1.0.0/16"
+# }
+
+# -----------------------------------------------------------------------------
+# Lambda Module（例として記載）
+# -----------------------------------------------------------------------------
+# module "lambda" {
+#   source = "../../lambda"
+#
+#   project     = "zousho"
+#   environment = "prod"
+#   vpc_id      = module.vpc.vpc_id
+#   # ...
+# }
+
+# -----------------------------------------------------------------------------
+# CodeBuild Module（例として記載）
+# -----------------------------------------------------------------------------
+# module "codebuild" {
+#   source = "../../codebuild"
+#
+#   project     = "zousho"
+#   environment = "prod"
+#   vpc_id      = module.vpc.vpc_id
+#   # ...
+# }
+
+# -----------------------------------------------------------------------------
+# RDS Module - Production Configuration
+# -----------------------------------------------------------------------------
+module "rds" {
+  source = "../.."
+
+  project     = "zousho"
+  environment = "prod"
+
+  # ネットワーク設定
+  # vpc_id             = module.vpc.vpc_id
+  # private_subnet_ids = module.vpc.private_subnet_ids
+
+  # データベース設定
+  db_name     = "zousho"
+  db_username = "postgres"
+  db_port     = 5432
+
+  # インスタンス設定（本番環境）
+  instance_class        = "db.t3.small" # より高性能なインスタンス
+  allocated_storage     = 100           # 初期ストレージ 100GB
+  max_allocated_storage = 500           # 自動スケーリング上限 500GB
+  engine_version        = "15.5"
+
+  # 高可用性設定
+  # 注意: Multi-AZ を有効にするとコストが約2倍になります
+  # 予算と可用性要件に応じて設定してください
+  multi_az = false # 小規模システムの場合は false でも可
+
+  # 削除保護（本番環境必須）
+  deletion_protection = true  # 誤削除を防止
+  skip_final_snapshot = false # 削除時に必ず最終スナップショットを作成
+
+  # バックアップ設定（本番環境推奨）
+  backup_retention_period = 30                 # 30日間保持
+  backup_window           = "18:00-19:00"      # JST 03:00-04:00
+  maintenance_window      = "sun:19:00-sun:20:00" # JST 日曜 04:00-05:00
+
+  # ログ設定（パフォーマンス考慮）
+  log_statement = "ddl" # DDL のみログ出力（CREATE, ALTER, DROP など）
+
+  # モニタリング設定（本番環境推奨）
+  performance_insights_enabled    = true # クエリパフォーマンス分析
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+
+  # セキュリティグループ設定
+  # Lambda からの接続を許可
+  # lambda_security_group_id = module.lambda.security_group_id
+
+  # CodeBuild（DB マイグレーション）からの接続を許可
+  # codebuild_security_group_id = module.codebuild.security_group_id
+}
+
+# -----------------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------------
+output "db_endpoint" {
+  description = "RDS エンドポイント"
+  value       = module.rds.db_instance_endpoint
+}
+
+output "db_address" {
+  description = "RDS ホスト名"
+  value       = module.rds.db_instance_address
+}
+
+output "secret_arn" {
+  description = "Secrets Manager シークレット ARN"
+  value       = module.rds.secret_arn
+  sensitive   = true
+}
+
+output "secret_name" {
+  description = "Secrets Manager シークレット名"
+  value       = module.rds.secret_name
+}
+
+output "rds_security_group_id" {
+  description = "RDS セキュリティグループ ID（Lambda/CodeBuild に設定）"
+  value       = module.rds.rds_security_group_id
+}
+
+# -----------------------------------------------------------------------------
+# 本番環境運用ガイド
+# -----------------------------------------------------------------------------
+# 1. 接続情報の確認
+#    aws secretsmanager get-secret-value \
+#      --secret-id zousho/prod/rds/credentials \
+#      --query SecretString \
+#      --output text | jq .
+#
+# 2. バックアップの確認
+#    aws rds describe-db-snapshots \
+#      --db-instance-identifier zousho-prod-db
+#
+# 3. Performance Insights の確認
+#    AWS マネジメントコンソール > RDS > Performance Insights
+#
+# 4. CloudWatch Logs の確認
+#    aws logs tail /aws/rds/instance/zousho-prod-db/postgresql --follow
+#
+# 5. 削除時の注意事項
+#    deletion_protection = true のため、削除前に以下の手順が必要:
+#    a. deletion_protection = false に変更して terraform apply
+#    b. terraform destroy を実行
+#    c. 最終スナップショットが自動作成される
+#
+# 6. スナップショットからの復元
+#    aws rds restore-db-instance-from-db-snapshot \
+#      --db-instance-identifier zousho-prod-db-restored \
+#      --db-snapshot-identifier <snapshot-id>

--- a/app/infra/modules/rds/main.tf
+++ b/app/infra/modules/rds/main.tf
@@ -90,7 +90,7 @@ resource "aws_db_parameter_group" "main" {
   # ログ設定
   parameter {
     name  = "log_statement"
-    value = "all"
+    value = var.log_statement
   }
 
   parameter {

--- a/app/infra/modules/rds/main.tf
+++ b/app/infra/modules/rds/main.tf
@@ -1,0 +1,166 @@
+# -----------------------------------------------------------------------------
+# Random Password for RDS Master User
+# -----------------------------------------------------------------------------
+resource "random_password" "master" {
+  length  = 32
+  special = true
+  # RDS パスワード制約: @, ", / は使用不可
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+# -----------------------------------------------------------------------------
+# RDS Security Group
+# -----------------------------------------------------------------------------
+resource "aws_security_group" "rds" {
+  name        = "${var.project}-${var.environment}-rds-sg"
+  description = "Security group for RDS PostgreSQL"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-rds-sg"
+    Environment = var.environment
+    Project     = var.project
+  }
+}
+
+# Lambda からの接続を許可
+resource "aws_vpc_security_group_ingress_rule" "from_lambda" {
+  count = var.lambda_security_group_id != "" ? 1 : 0
+
+  security_group_id            = aws_security_group.rds.id
+  referenced_security_group_id = var.lambda_security_group_id
+  from_port                    = var.db_port
+  to_port                      = var.db_port
+  ip_protocol                  = "tcp"
+  description                  = "Allow PostgreSQL from Lambda"
+
+  tags = {
+    Name = "from-lambda"
+  }
+}
+
+# CodeBuild からの接続を許可
+resource "aws_vpc_security_group_ingress_rule" "from_codebuild" {
+  count = var.codebuild_security_group_id != "" ? 1 : 0
+
+  security_group_id            = aws_security_group.rds.id
+  referenced_security_group_id = var.codebuild_security_group_id
+  from_port                    = var.db_port
+  to_port                      = var.db_port
+  ip_protocol                  = "tcp"
+  description                  = "Allow PostgreSQL from CodeBuild"
+
+  tags = {
+    Name = "from-codebuild"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# DB Subnet Group
+# -----------------------------------------------------------------------------
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project}-${var.environment}-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-db-subnet-group"
+    Environment = var.environment
+    Project     = var.project
+  }
+}
+
+# -----------------------------------------------------------------------------
+# DB Parameter Group
+# -----------------------------------------------------------------------------
+resource "aws_db_parameter_group" "main" {
+  name   = "${var.project}-${var.environment}-postgres15"
+  family = "postgres15"
+
+  # 日本語対応
+  parameter {
+    name  = "client_encoding"
+    value = "UTF8"
+  }
+
+  parameter {
+    name  = "timezone"
+    value = "Asia/Tokyo"
+  }
+
+  # ログ設定
+  parameter {
+    name  = "log_statement"
+    value = "all"
+  }
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "1000" # 1秒以上のクエリをログ出力
+  }
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-postgres15"
+    Environment = var.environment
+    Project     = var.project
+  }
+}
+
+# -----------------------------------------------------------------------------
+# RDS Instance
+# -----------------------------------------------------------------------------
+resource "aws_db_instance" "main" {
+  identifier = "${var.project}-${var.environment}-db"
+
+  # Engine
+  engine         = "postgres"
+  engine_version = var.engine_version
+
+  # Instance
+  instance_class        = var.instance_class
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = var.max_allocated_storage
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  # Database
+  db_name  = var.db_name
+  username = var.db_username
+  password = random_password.master.result
+  port     = var.db_port
+
+  # Network
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  publicly_accessible    = false
+  multi_az               = var.multi_az
+
+  # Parameter & Option Group
+  parameter_group_name = aws_db_parameter_group.main.name
+
+  # Backup
+  backup_retention_period   = var.backup_retention_period
+  backup_window             = var.backup_window
+  skip_final_snapshot       = var.skip_final_snapshot
+  final_snapshot_identifier = var.skip_final_snapshot ? null : "${var.project}-${var.environment}-db-final-snapshot-${formatdate("YYYYMMDD-hhmm", timestamp())}"
+
+  # Maintenance
+  maintenance_window              = var.maintenance_window
+  auto_minor_version_upgrade      = true
+  deletion_protection             = var.deletion_protection
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
+
+  # Monitoring
+  performance_insights_enabled = var.performance_insights_enabled
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-db"
+    Environment = var.environment
+    Project     = var.project
+  }
+
+  lifecycle {
+    ignore_changes = [
+      final_snapshot_identifier,
+    ]
+  }
+}

--- a/app/infra/modules/rds/outputs.tf
+++ b/app/infra/modules/rds/outputs.tf
@@ -1,0 +1,59 @@
+# -----------------------------------------------------------------------------
+# RDS Instance Outputs
+# -----------------------------------------------------------------------------
+output "db_instance_id" {
+  description = "RDS インスタンス ID"
+  value       = aws_db_instance.main.id
+}
+
+output "db_instance_arn" {
+  description = "RDS インスタンス ARN"
+  value       = aws_db_instance.main.arn
+}
+
+output "db_instance_endpoint" {
+  description = "RDS インスタンス エンドポイント"
+  value       = aws_db_instance.main.endpoint
+}
+
+output "db_instance_address" {
+  description = "RDS インスタンス ホスト名"
+  value       = aws_db_instance.main.address
+}
+
+output "db_instance_port" {
+  description = "RDS インスタンス ポート番号"
+  value       = aws_db_instance.main.port
+}
+
+output "db_name" {
+  description = "データベース名"
+  value       = aws_db_instance.main.db_name
+}
+
+output "db_username" {
+  description = "マスターユーザー名"
+  value       = aws_db_instance.main.username
+  sensitive   = true
+}
+
+# -----------------------------------------------------------------------------
+# Security Group Outputs
+# -----------------------------------------------------------------------------
+output "rds_security_group_id" {
+  description = "RDS セキュリティグループ ID"
+  value       = aws_security_group.rds.id
+}
+
+# -----------------------------------------------------------------------------
+# Secrets Manager Outputs
+# -----------------------------------------------------------------------------
+output "secret_arn" {
+  description = "Secrets Manager シークレット ARN"
+  value       = aws_secretsmanager_secret.rds.arn
+}
+
+output "secret_name" {
+  description = "Secrets Manager シークレット名"
+  value       = aws_secretsmanager_secret.rds.name
+}

--- a/app/infra/modules/rds/secrets.tf
+++ b/app/infra/modules/rds/secrets.tf
@@ -23,7 +23,7 @@ resource "aws_secretsmanager_secret_version" "rds" {
     host     = aws_db_instance.main.address
     port     = aws_db_instance.main.port
     dbname   = aws_db_instance.main.db_name
-    # 接続文字列も含める
-    connection_string = "postgresql://${aws_db_instance.main.username}:${random_password.master.result}@${aws_db_instance.main.address}:${aws_db_instance.main.port}/${aws_db_instance.main.db_name}"
+    # 接続文字列も含める（特殊文字をURLエンコード）
+    connection_string = "postgresql://${urlencode(aws_db_instance.main.username)}:${urlencode(random_password.master.result)}@${aws_db_instance.main.address}:${aws_db_instance.main.port}/${aws_db_instance.main.db_name}"
   })
 }

--- a/app/infra/modules/rds/secrets.tf
+++ b/app/infra/modules/rds/secrets.tf
@@ -1,0 +1,29 @@
+# -----------------------------------------------------------------------------
+# Secrets Manager for RDS Connection
+# -----------------------------------------------------------------------------
+resource "aws_secretsmanager_secret" "rds" {
+  name        = "${var.project}/${var.environment}/rds/credentials"
+  description = "RDS PostgreSQL connection credentials for ${var.environment} environment"
+
+  recovery_window_in_days = var.environment == "prod" ? 30 : 0
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-rds-secret"
+    Environment = var.environment
+    Project     = var.project
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "rds" {
+  secret_id = aws_secretsmanager_secret.rds.id
+  secret_string = jsonencode({
+    username = aws_db_instance.main.username
+    password = random_password.master.result
+    engine   = "postgres"
+    host     = aws_db_instance.main.address
+    port     = aws_db_instance.main.port
+    dbname   = aws_db_instance.main.db_name
+    # 接続文字列も含める
+    connection_string = "postgresql://${aws_db_instance.main.username}:${random_password.master.result}@${aws_db_instance.main.address}:${aws_db_instance.main.port}/${aws_db_instance.main.db_name}"
+  })
+}

--- a/app/infra/modules/rds/variables.tf
+++ b/app/infra/modules/rds/variables.tf
@@ -99,15 +99,15 @@ variable "maintenance_window" {
 }
 
 variable "deletion_protection" {
-  description = "削除保護の有効化"
+  description = "削除保護の有効化（本番環境推奨: true）"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "skip_final_snapshot" {
-  description = "削除時に最終スナップショットをスキップ"
+  description = "削除時に最終スナップショットをスキップ（本番環境推奨: false）"
   type        = bool
-  default     = true
+  default     = false
 }
 
 # -----------------------------------------------------------------------------
@@ -123,6 +123,20 @@ variable "codebuild_security_group_id" {
   description = "CodeBuild セキュリティグループ ID（接続許可用）"
   type        = string
   default     = ""
+}
+
+# -----------------------------------------------------------------------------
+# Logging Variables
+# -----------------------------------------------------------------------------
+variable "log_statement" {
+  description = "ログに記録するSQL文の種類（none/ddl/mod/all）。本番環境推奨: ddl"
+  type        = string
+  default     = "ddl"
+
+  validation {
+    condition     = contains(["none", "ddl", "mod", "all"], var.log_statement)
+    error_message = "log_statement must be one of: none, ddl, mod, all"
+  }
 }
 
 # -----------------------------------------------------------------------------

--- a/app/infra/modules/rds/variables.tf
+++ b/app/infra/modules/rds/variables.tf
@@ -1,0 +1,141 @@
+# -----------------------------------------------------------------------------
+# Common Variables
+# -----------------------------------------------------------------------------
+variable "project" {
+  description = "プロジェクト名"
+  type        = string
+}
+
+variable "environment" {
+  description = "環境名（dev/prod）"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "prod"], var.environment)
+    error_message = "environment must be dev or prod"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Network Variables
+# -----------------------------------------------------------------------------
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "Private Subnet IDs（RDS配置用）"
+  type        = list(string)
+}
+
+# -----------------------------------------------------------------------------
+# RDS Instance Variables
+# -----------------------------------------------------------------------------
+variable "db_name" {
+  description = "データベース名"
+  type        = string
+  default     = "zousho"
+}
+
+variable "db_username" {
+  description = "マスターユーザー名"
+  type        = string
+  default     = "postgres"
+}
+
+variable "db_port" {
+  description = "データベースポート番号"
+  type        = number
+  default     = 5432
+}
+
+variable "instance_class" {
+  description = "RDS インスタンスクラス"
+  type        = string
+  default     = "db.t3.micro"
+}
+
+variable "allocated_storage" {
+  description = "割り当てストレージ容量（GB）"
+  type        = number
+  default     = 20
+}
+
+variable "max_allocated_storage" {
+  description = "自動ストレージスケーリングの最大容量（GB）"
+  type        = number
+  default     = 100
+}
+
+variable "engine_version" {
+  description = "PostgreSQL エンジンバージョン"
+  type        = string
+  default     = "15.5"
+}
+
+variable "multi_az" {
+  description = "Multi-AZ 構成の有効化"
+  type        = bool
+  default     = false
+}
+
+variable "backup_retention_period" {
+  description = "バックアップ保持期間（日数）"
+  type        = number
+  default     = 7
+}
+
+variable "backup_window" {
+  description = "バックアップ実行時間（UTC）"
+  type        = string
+  default     = "18:00-19:00" # JST 03:00-04:00
+}
+
+variable "maintenance_window" {
+  description = "メンテナンス実行時間（UTC）"
+  type        = string
+  default     = "sun:19:00-sun:20:00" # JST 日曜 04:00-05:00
+}
+
+variable "deletion_protection" {
+  description = "削除保護の有効化"
+  type        = bool
+  default     = false
+}
+
+variable "skip_final_snapshot" {
+  description = "削除時に最終スナップショットをスキップ"
+  type        = bool
+  default     = true
+}
+
+# -----------------------------------------------------------------------------
+# Security Variables
+# -----------------------------------------------------------------------------
+variable "lambda_security_group_id" {
+  description = "Lambda セキュリティグループ ID（接続許可用）"
+  type        = string
+  default     = ""
+}
+
+variable "codebuild_security_group_id" {
+  description = "CodeBuild セキュリティグループ ID（接続許可用）"
+  type        = string
+  default     = ""
+}
+
+# -----------------------------------------------------------------------------
+# Monitoring Variables
+# -----------------------------------------------------------------------------
+variable "enabled_cloudwatch_logs_exports" {
+  description = "CloudWatch Logs へ出力するログの種類"
+  type        = list(string)
+  default     = ["postgresql", "upgrade"]
+}
+
+variable "performance_insights_enabled" {
+  description = "Performance Insights の有効化"
+  type        = bool
+  default     = false
+}

--- a/app/infra/modules/rds/versions.tf
+++ b/app/infra/modules/rds/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}


### PR DESCRIPTION
## 概要

Issue #2 の対応として、Amazon RDS for PostgreSQL のTerraformモジュールを実装しました。

## 関連 Issue

Closes #2

## 変更内容

### 実装したリソース

1. **RDS PostgreSQL インスタンス** ([main.tf:111-167](app/infra/modules/rds/main.tf#L111-L167))
   - PostgreSQL 15.5
   - プライベートサブネットに配置
   - ストレージ暗号化有効
   - 自動バックアップ設定（7日間保持）

2. **セキュリティグループ** ([main.tf:13-59](app/infra/modules/rds/main.tf#L13-L59))
   - Lambda/CodeBuildからのPostgreSQL接続（5432/tcp）のみ許可
   - 条件付きリソース作成（`count`）で段階的構築に対応

3. **DBサブネットグループ** ([main.tf:64-74](app/infra/modules/rds/main.tf#L64-L74))
   - プライベートサブネットを使用

4. **DBパラメータグループ** ([main.tf:79-106](app/infra/modules/rds/main.tf#L79-L106))
   - 日本語対応（UTF8、Asia/Tokyo）
   - ログ設定（1秒以上のクエリを記録）

5. **Secrets Manager** ([secrets.tf](app/infra/modules/rds/secrets.tf))
   - DB接続情報の自動登録
   - 接続文字列も含む
   - 環境別リカバリー期間設定

### セキュリティ対策

- ✅ RDSはプライベートサブネットに配置
- ✅ パブリックアクセス無効化
- ✅ ストレージ暗号化有効
- ✅ Lambda/CodeBuildからのみ接続許可
- ✅ Secrets Managerでパスワード管理
- ✅ ランダムパスワード自動生成（32文字）

### 変数設計

- 環境別設定（dev/prod）に対応
- インスタンスクラス、ストレージ、Multi-AZなど柔軟に設定可能
- バリデーション付き（environmentは`dev`または`prod`のみ）

## テスト方法

```bash
cd app/infra/modules/rds

# 初期化
terraform init

# フォーマット確認
terraform fmt -check -recursive

# 構文検証
terraform validate
```

## チェックリスト

- [x] Terraformフォーマット済み（`terraform fmt`）
- [x] 構文検証済み（`terraform validate`）
- [x] セキュリティ要件を満たしている
- [x] ドキュメント参照（database-design.md, system-architecture.md）
- [x] 変数にバリデーション設定
- [x] 環境別設定に対応

## 備考

### 段階的構築への対応

Lambda/CodeBuildモジュールが未作成の段階でもエラーにならないよう、セキュリティグループのインバウンドルールは`count`を使用した条件付きリソースとして実装しています。

```terraform
# Lambda SGが指定された場合のみルールを作成
resource "aws_vpc_security_group_ingress_rule" "from_lambda" {
  count = var.lambda_security_group_id != "" ? 1 : 0
  ...
}
```

### Next Steps

- INFRA-003: Lambda モジュールの実装
- INFRA-004: CodeBuild（DBマイグレーション）の実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)