### PR TITLE
feat: Cognito User Pool モジュールを実装 (#3)

### DIFF
--- a/app/infra/modules/cognito/README.md
+++ b/app/infra/modules/cognito/README.md
@@ -1,0 +1,360 @@
+# Cognito Module
+
+Amazon Cognito User Poolを構築するTerraformモジュール。
+
+## 概要
+
+このモジュールは、以下のリソースを作成します：
+
+- **Cognito User Pool**: ユーザー認証基盤
+- **Cognito User Pool Client**: アプリケーションクライアント
+- **Cognito User Pool Domain**: （オプション）認証UIのドメイン
+- **Cognito User Groups**: ユーザーグループ（管理者、一般ユーザーなど）
+
+## 主な機能
+
+- ✅ 柔軟なパスワードポリシー設定
+- ✅ MFA（多要素認証）サポート
+- ✅ OAuth 2.0 / OpenID Connect対応
+- ✅ カスタム属性スキーマ定義
+- ✅ ユーザーグループ管理
+- ✅ セキュリティベストプラクティス適用
+
+## 使用方法
+
+### 基本的な構成
+
+```hcl
+module "cognito" {
+  source = "../../modules/cognito"
+
+  user_pool_name  = "zousho-dev-user-pool"
+  app_client_name = "zousho-dev-app-client"
+
+  # パスワードポリシー
+  password_policy = {
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_uppercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    temporary_password_validity_days = 7
+  }
+
+  # 管理者グループ
+  user_groups = [
+    {
+      name        = "admin"
+      description = "管理者グループ"
+      precedence  = 1
+    },
+    {
+      name        = "user"
+      description = "一般ユーザーグループ"
+      precedence  = 10
+    }
+  ]
+
+  tags = {
+    Environment = "dev"
+    Project     = "zousho"
+  }
+}
+```
+
+### OAuth設定を含む構成
+
+```hcl
+module "cognito" {
+  source = "../../modules/cognito"
+
+  user_pool_name  = "zousho-prod-user-pool"
+  app_client_name = "zousho-prod-app-client"
+
+  # OAuth設定
+  oauth_flows         = ["code"]
+  oauth_flows_enabled = true
+  oauth_scopes        = ["openid", "email", "profile"]
+  callback_urls       = ["https://example.com/callback"]
+  logout_urls         = ["https://example.com/logout"]
+
+  # ドメイン設定
+  domain = "zousho-prod-auth"
+
+  tags = {
+    Environment = "prod"
+    Project     = "zousho"
+  }
+}
+```
+
+### カスタム属性を含む構成
+
+```hcl
+module "cognito" {
+  source = "../../modules/cognito"
+
+  user_pool_name  = "zousho-dev-user-pool"
+  app_client_name = "zousho-dev-app-client"
+
+  # カスタム属性スキーマ
+  schemas = [
+    {
+      name                = "department"
+      attribute_data_type = "String"
+      mutable             = true
+      required            = false
+      min_length          = 1
+      max_length          = 100
+    },
+    {
+      name                = "employee_id"
+      attribute_data_type = "String"
+      mutable             = false
+      required            = true
+      min_length          = 4
+      max_length          = 10
+    }
+  ]
+
+  tags = {
+    Environment = "dev"
+    Project     = "zousho"
+  }
+}
+```
+
+## 入力変数
+
+### 必須変数
+
+| 変数名 | 説明 | 型 |
+|--------|------|-----|
+| `user_pool_name` | Cognito User Poolの名前 | `string` |
+| `app_client_name` | App Clientの名前 | `string` |
+
+### オプション変数
+
+#### User Pool設定
+
+| 変数名 | 説明 | 型 | デフォルト |
+|--------|------|-----|-----------|
+| `username_attributes` | ユーザー名として使用する属性 | `list(string)` | `["email"]` |
+| `username_case_sensitive` | ユーザー名の大文字小文字を区別するか | `bool` | `false` |
+| `auto_verified_attributes` | 自動検証する属性 | `list(string)` | `["email"]` |
+| `mfa_configuration` | MFA設定（OFF, OPTIONAL, ON） | `string` | `"OPTIONAL"` |
+
+#### パスワードポリシー
+
+| 変数名 | 説明 | 型 | デフォルト |
+|--------|------|-----|-----------|
+| `password_policy` | パスワードポリシーの設定 | `object` | 下記参照 |
+
+デフォルトのパスワードポリシー:
+```hcl
+{
+  minimum_length                   = 8
+  require_lowercase                = true
+  require_uppercase                = true
+  require_numbers                  = true
+  require_symbols                  = true
+  temporary_password_validity_days = 7
+}
+```
+
+#### App Client設定
+
+| 変数名 | 説明 | 型 | デフォルト |
+|--------|------|-----|-----------|
+| `oauth_flows` | 許可するOAuthフロー | `list(string)` | `["code"]` |
+| `oauth_flows_enabled` | OAuthフローを有効にするか | `bool` | `true` |
+| `oauth_scopes` | 許可するOAuthスコープ | `list(string)` | `["openid", "email", "profile"]` |
+| `callback_urls` | コールバックURL | `list(string)` | `[]` |
+| `logout_urls` | ログアウトURL | `list(string)` | `[]` |
+| `generate_client_secret` | クライアントシークレットを生成するか | `bool` | `false` |
+
+#### トークン有効期限
+
+| 変数名 | 説明 | 型 | デフォルト |
+|--------|------|-----|-----------|
+| `token_validity` | トークンの有効期限 | `object` | 下記参照 |
+
+デフォルトのトークン有効期限:
+```hcl
+{
+  refresh_token_validity = 30     # 30日
+  access_token_validity  = 60     # 60分
+  id_token_validity      = 60     # 60分
+}
+```
+
+#### ユーザーグループ
+
+| 変数名 | 説明 | 型 | デフォルト |
+|--------|------|-----|-----------|
+| `user_groups` | 作成するユーザーグループのリスト | `list(object)` | `[]` |
+
+ユーザーグループの構造:
+```hcl
+[
+  {
+    name        = "admin"           # 必須: グループ名
+    description = "管理者グループ"    # オプション: 説明
+    precedence  = 1                 # オプション: 優先度（小さいほど高い）
+    role_arn    = "arn:aws:..."     # オプション: IAMロールARN
+  }
+]
+```
+
+#### その他
+
+| 変数名 | 説明 | 型 | デフォルト |
+|--------|------|-----|-----------|
+| `domain` | Cognito User Pool Domain（空文字の場合は作成しない） | `string` | `""` |
+| `schemas` | カスタム属性スキーマ | `list(object)` | `[]` |
+| `tags` | リソースに付与するタグ | `map(string)` | `{}` |
+
+## 出力変数
+
+| 変数名 | 説明 |
+|--------|------|
+| `user_pool_id` | Cognito User Pool ID |
+| `user_pool_arn` | Cognito User Pool ARN |
+| `user_pool_name` | Cognito User Pool Name |
+| `user_pool_endpoint` | Cognito User Pool Endpoint |
+| `app_client_id` | Cognito User Pool App Client ID |
+| `app_client_secret` | Cognito User Pool App Client Secret（sensitive） |
+| `domain` | Cognito User Pool Domain |
+| `user_groups` | Cognito User Groups |
+
+## セキュリティ考慮事項
+
+### パスワードポリシー
+
+本番環境では強力なパスワードポリシーを設定してください：
+
+```hcl
+password_policy = {
+  minimum_length                   = 12  # 最低12文字
+  require_lowercase                = true
+  require_uppercase                = true
+  require_numbers                  = true
+  require_symbols                  = true
+  temporary_password_validity_days = 7
+}
+```
+
+### MFA（多要素認証）
+
+本番環境ではMFAを必須または推奨に設定してください：
+
+```hcl
+mfa_configuration = "ON"  # または "OPTIONAL"
+```
+
+### トークン有効期限
+
+セキュリティ要件に応じてトークンの有効期限を調整してください：
+
+```hcl
+token_validity = {
+  refresh_token_validity = 7      # 7日（短めに設定）
+  access_token_validity  = 15     # 15分（短めに設定）
+  id_token_validity      = 15     # 15分（短めに設定）
+}
+```
+
+### ユーザー列挙攻撃の防止
+
+デフォルトで有効化されていますが、明示的に設定することを推奨：
+
+```hcl
+prevent_user_existence_errors = "ENABLED"
+```
+
+### クライアントシークレット
+
+サーバーサイドアプリケーションの場合はクライアントシークレットを使用：
+
+```hcl
+generate_client_secret = true
+```
+
+## ベストプラクティス
+
+### 1. 環境ごとの分離
+
+dev/prod環境でUser Poolを分離してください：
+
+```hcl
+# dev環境
+user_pool_name = "zousho-dev-user-pool"
+
+# prod環境
+user_pool_name = "zousho-prod-user-pool"
+```
+
+### 2. ユーザーグループの活用
+
+権限管理にはユーザーグループを活用してください：
+
+```hcl
+user_groups = [
+  {
+    name        = "admin"
+    description = "管理者：すべての操作が可能"
+    precedence  = 1
+  },
+  {
+    name        = "editor"
+    description = "編集者：書籍の追加・編集が可能"
+    precedence  = 5
+  },
+  {
+    name        = "viewer"
+    description = "閲覧者：閲覧のみ可能"
+    precedence  = 10
+  }
+]
+```
+
+### 3. タグの活用
+
+リソースの管理にタグを活用してください：
+
+```hcl
+tags = {
+  Environment = "prod"
+  Project     = "zousho"
+  ManagedBy   = "terraform"
+  Owner       = "platform-team"
+}
+```
+
+### 4. ライフサイクル管理
+
+User Poolは誤削除を防ぐため `prevent_destroy` を設定しています。削除が必要な場合は、設定を明示的に変更してください。
+
+## トラブルシューティング
+
+### User Poolが作成できない
+
+- リージョンの設定を確認してください
+- IAM権限を確認してください（`cognito-idp:*` 権限が必要）
+
+### ドメインが作成できない
+
+- ドメイン名は小文字英数字とハイフンのみ使用可能です
+- ドメイン名は一意である必要があります（リージョン内）
+
+### カスタム属性が追加できない
+
+- User Pool作成後、カスタム属性の削除はできません
+- 属性の追加のみ可能です
+
+## 参考資料
+
+- [AWS Cognito User Pools 公式ドキュメント](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html)
+- [Terraform AWS Provider - Cognito User Pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool)
+- [OAuth 2.0](https://oauth.net/2/)
+- [OpenID Connect](https://openid.net/connect/)

--- a/app/infra/modules/cognito/examples/dev/main.tf
+++ b/app/infra/modules/cognito/examples/dev/main.tf
@@ -1,0 +1,225 @@
+# -----------------------------------------------------------------------------
+# Cognito Module - Development Environment Example
+# -----------------------------------------------------------------------------
+# この例は開発環境向けの推奨設定を示しています。
+# 開発効率を優先しつつ、セキュリティのベストプラクティスを適用した構成です。
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+
+  default_tags {
+    tags = {
+      Environment = "dev"
+      Project     = "zousho"
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Cognito Module - Dev Configuration
+# -----------------------------------------------------------------------------
+module "cognito" {
+  source = "../.."
+
+  user_pool_name  = "zousho-dev-user-pool"
+  app_client_name = "zousho-dev-app-client"
+
+  # ユーザー名設定
+  username_attributes      = ["email"]
+  username_case_sensitive  = false
+  auto_verified_attributes = ["email"]
+
+  # MFA設定（開発環境では任意）
+  mfa_configuration = "OPTIONAL"
+
+  # パスワードポリシー（開発環境向け：やや緩め）
+  password_policy = {
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_uppercase                = true
+    require_numbers                  = true
+    require_symbols                  = false # 開発環境では記号を任意に
+    temporary_password_validity_days = 7
+  }
+
+  # アカウント回復設定
+  account_recovery_mechanism = {
+    name     = "verified_email"
+    priority = 1
+  }
+
+  # OAuth設定
+  oauth_flows         = ["code"]
+  oauth_flows_enabled = true
+  oauth_scopes        = ["openid", "email", "profile"]
+
+  # コールバックURL（ローカル開発用）
+  callback_urls = [
+    "http://localhost:5173/callback", # Frontend (Vite)
+    "http://localhost:3000/callback"  # Admin (React Admin)
+  ]
+
+  # ログアウトURL
+  logout_urls = [
+    "http://localhost:5173/",
+    "http://localhost:3000/"
+  ]
+
+  # 認証フロー
+  explicit_auth_flows = [
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_USER_PASSWORD_AUTH" # 開発環境では簡易認証も許可
+  ]
+
+  # トークン有効期限（開発環境：長めに設定）
+  token_validity = {
+    refresh_token_validity = 30 # 30日
+    access_token_validity  = 60 # 60分
+    id_token_validity      = 60 # 60分
+  }
+
+  token_validity_units = {
+    refresh_token = "days"
+    access_token  = "minutes"
+    id_token      = "minutes"
+  }
+
+  # セキュリティ設定
+  generate_client_secret                        = false # SPA用
+  enable_token_revocation                       = true
+  prevent_user_existence_errors                 = "ENABLED"
+  enable_propagate_additional_user_context_data = false
+
+  # 読み書き可能な属性
+  read_attributes = [
+    "email",
+    "email_verified",
+    "name"
+  ]
+
+  write_attributes = [
+    "email",
+    "name"
+  ]
+
+  # サポートする認証プロバイダー
+  supported_identity_providers = ["COGNITO"]
+
+  # ユーザーグループ
+  user_groups = [
+    {
+      name        = "admin"
+      description = "管理者グループ - すべての操作が可能"
+      precedence  = 1
+    },
+    {
+      name        = "user"
+      description = "一般ユーザーグループ - 基本的な操作が可能"
+      precedence  = 10
+    }
+  ]
+
+  # カスタム属性（例）
+  schemas = [
+    {
+      name                = "department"
+      attribute_data_type = "String"
+      mutable             = true
+      required            = false
+      min_length          = 1
+      max_length          = 100
+    }
+  ]
+
+  # ドメイン設定（開発環境用）
+  domain = "zousho-dev-auth"
+
+  tags = {
+    Environment = "dev"
+    Project     = "zousho"
+    ManagedBy   = "terraform"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------------
+output "user_pool_id" {
+  description = "Cognito User Pool ID"
+  value       = module.cognito.user_pool_id
+}
+
+output "user_pool_arn" {
+  description = "Cognito User Pool ARN"
+  value       = module.cognito.user_pool_arn
+}
+
+output "user_pool_endpoint" {
+  description = "Cognito User Pool Endpoint"
+  value       = module.cognito.user_pool_endpoint
+}
+
+output "app_client_id" {
+  description = "Cognito App Client ID"
+  value       = module.cognito.app_client_id
+}
+
+output "domain" {
+  description = "Cognito User Pool Domain"
+  value       = module.cognito.domain
+}
+
+output "user_groups" {
+  description = "Cognito User Groups"
+  value       = module.cognito.user_groups
+}
+
+# -----------------------------------------------------------------------------
+# 使用例
+# -----------------------------------------------------------------------------
+# 1. Terraform を初期化:
+#    cd app/infra/modules/cognito/examples/dev
+#    terraform init
+#
+# 2. 実行計画を確認:
+#    terraform plan
+#
+# 3. リソースを作成:
+#    terraform apply
+#
+# 4. User Pool ID を確認:
+#    terraform output user_pool_id
+#
+# 5. テストユーザーを作成（AWS CLI）:
+#    aws cognito-idp admin-create-user \
+#      --user-pool-id <USER_POOL_ID> \
+#      --username test@example.com \
+#      --user-attributes Name=email,Value=test@example.com Name=email_verified,Value=true \
+#      --message-action SUPPRESS
+#
+# 6. ユーザーをグループに追加:
+#    aws cognito-idp admin-add-user-to-group \
+#      --user-pool-id <USER_POOL_ID> \
+#      --username test@example.com \
+#      --group-name admin
+#
+# 7. パスワードを設定:
+#    aws cognito-idp admin-set-user-password \
+#      --user-pool-id <USER_POOL_ID> \
+#      --username test@example.com \
+#      --password 'TempPassword123!' \
+#      --permanent

--- a/app/infra/modules/cognito/main.tf
+++ b/app/infra/modules/cognito/main.tf
@@ -1,0 +1,158 @@
+#######################################################
+# Cognito User Pool
+#######################################################
+
+resource "aws_cognito_user_pool" "main" {
+  name = var.user_pool_name
+
+  # パスワードポリシー
+  password_policy {
+    minimum_length                   = var.password_policy.minimum_length
+    require_lowercase                = var.password_policy.require_lowercase
+    require_uppercase                = var.password_policy.require_uppercase
+    require_numbers                  = var.password_policy.require_numbers
+    require_symbols                  = var.password_policy.require_symbols
+    temporary_password_validity_days = var.password_policy.temporary_password_validity_days
+  }
+
+  # ユーザー名属性
+  username_attributes = var.username_attributes
+
+  # ユーザー名の大文字小文字を区別しない
+  username_configuration {
+    case_sensitive = var.username_case_sensitive
+  }
+
+  # 自動検証する属性
+  auto_verified_attributes = var.auto_verified_attributes
+
+  # MFA設定
+  mfa_configuration = var.mfa_configuration
+
+  # アカウント回復設定
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = var.account_recovery_mechanism.name
+      priority = var.account_recovery_mechanism.priority
+    }
+  }
+
+  # メール設定
+  email_configuration {
+    email_sending_account = var.email_configuration.email_sending_account
+  }
+
+  # デバイス記憶設定
+  device_configuration {
+    challenge_required_on_new_device      = var.device_configuration.challenge_required_on_new_device
+    device_only_remembered_on_user_prompt = var.device_configuration.device_only_remembered_on_user_prompt
+  }
+
+  # ユーザー属性のスキーマ
+  dynamic "schema" {
+    for_each = var.schemas
+    content {
+      name                     = schema.value.name
+      attribute_data_type      = schema.value.attribute_data_type
+      developer_only_attribute = lookup(schema.value, "developer_only_attribute", false)
+      mutable                  = lookup(schema.value, "mutable", true)
+      required                 = lookup(schema.value, "required", false)
+
+      dynamic "string_attribute_constraints" {
+        for_each = schema.value.attribute_data_type == "String" ? [1] : []
+        content {
+          min_length = lookup(schema.value, "min_length", 0)
+          max_length = lookup(schema.value, "max_length", 2048)
+        }
+      }
+
+      dynamic "number_attribute_constraints" {
+        for_each = schema.value.attribute_data_type == "Number" ? [1] : []
+        content {
+          min_value = lookup(schema.value, "min_value", null)
+          max_value = lookup(schema.value, "max_value", null)
+        }
+      }
+    }
+  }
+
+  # タグ
+  tags = merge(
+    var.tags,
+    {
+      Name = var.user_pool_name
+    }
+  )
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+#######################################################
+# Cognito User Pool Client
+#######################################################
+
+resource "aws_cognito_user_pool_client" "main" {
+  name         = var.app_client_name
+  user_pool_id = aws_cognito_user_pool.main.id
+
+  # OAuth設定
+  allowed_oauth_flows                  = var.oauth_flows
+  allowed_oauth_flows_user_pool_client = var.oauth_flows_enabled
+  allowed_oauth_scopes                 = var.oauth_scopes
+  callback_urls                        = var.callback_urls
+  logout_urls                          = var.logout_urls
+
+  # サポートする認証フロー
+  explicit_auth_flows = var.explicit_auth_flows
+
+  # トークンの有効期限
+  refresh_token_validity = var.token_validity.refresh_token_validity
+  access_token_validity  = var.token_validity.access_token_validity
+  id_token_validity      = var.token_validity.id_token_validity
+
+  token_validity_units {
+    refresh_token = var.token_validity_units.refresh_token
+    access_token  = var.token_validity_units.access_token
+    id_token      = var.token_validity_units.id_token
+  }
+
+  # セキュリティ設定
+  generate_secret                               = var.generate_client_secret
+  enable_token_revocation                       = var.enable_token_revocation
+  prevent_user_existence_errors                 = var.prevent_user_existence_errors
+  enable_propagate_additional_user_context_data = var.enable_propagate_additional_user_context_data
+
+  # 読み書き可能な属性
+  read_attributes  = var.read_attributes
+  write_attributes = var.write_attributes
+
+  # サポートする認証プロバイダー
+  supported_identity_providers = var.supported_identity_providers
+}
+
+#######################################################
+# Cognito User Pool Domain (Optional)
+#######################################################
+
+resource "aws_cognito_user_pool_domain" "main" {
+  count = var.domain != "" ? 1 : 0
+
+  domain       = var.domain
+  user_pool_id = aws_cognito_user_pool.main.id
+}
+
+#######################################################
+# Cognito User Groups
+#######################################################
+
+resource "aws_cognito_user_group" "groups" {
+  for_each = { for group in var.user_groups : group.name => group }
+
+  name         = each.value.name
+  user_pool_id = aws_cognito_user_pool.main.id
+  description  = lookup(each.value, "description", null)
+  precedence   = lookup(each.value, "precedence", null)
+  role_arn     = lookup(each.value, "role_arn", null)
+}

--- a/app/infra/modules/cognito/outputs.tf
+++ b/app/infra/modules/cognito/outputs.tf
@@ -1,0 +1,73 @@
+#######################################################
+# User Pool Outputs
+#######################################################
+
+output "user_pool_id" {
+  description = "Cognito User Pool ID"
+  value       = aws_cognito_user_pool.main.id
+}
+
+output "user_pool_arn" {
+  description = "Cognito User Pool ARN"
+  value       = aws_cognito_user_pool.main.arn
+}
+
+output "user_pool_name" {
+  description = "Cognito User Pool Name"
+  value       = aws_cognito_user_pool.main.name
+}
+
+output "user_pool_endpoint" {
+  description = "Cognito User Pool Endpoint"
+  value       = aws_cognito_user_pool.main.endpoint
+}
+
+#######################################################
+# App Client Outputs
+#######################################################
+
+output "app_client_id" {
+  description = "Cognito User Pool App Client ID"
+  value       = aws_cognito_user_pool_client.main.id
+}
+
+output "app_client_secret" {
+  description = "Cognito User Pool App Client Secret (sensitive)"
+  value       = aws_cognito_user_pool_client.main.client_secret
+  sensitive   = true
+}
+
+#######################################################
+# Domain Outputs
+#######################################################
+
+output "domain" {
+  description = "Cognito User Pool Domain"
+  value       = var.domain != "" ? aws_cognito_user_pool_domain.main[0].domain : null
+}
+
+output "domain_cloudfront_distribution" {
+  description = "Cognito User Pool Domain CloudFront Distribution"
+  value       = var.domain != "" ? aws_cognito_user_pool_domain.main[0].cloudfront_distribution : null
+}
+
+output "domain_cloudfront_distribution_arn" {
+  description = "Cognito User Pool Domain CloudFront Distribution ARN"
+  value       = var.domain != "" ? aws_cognito_user_pool_domain.main[0].cloudfront_distribution_arn : null
+}
+
+#######################################################
+# User Groups Outputs
+#######################################################
+
+output "user_groups" {
+  description = "Cognito User Groups"
+  value = {
+    for name, group in aws_cognito_user_group.groups : name => {
+      id         = group.id
+      name       = group.name
+      precedence = group.precedence
+      role_arn   = group.role_arn
+    }
+  }
+}

--- a/app/infra/modules/cognito/variables.tf
+++ b/app/infra/modules/cognito/variables.tf
@@ -1,0 +1,336 @@
+#######################################################
+# User Pool Configuration
+#######################################################
+
+variable "user_pool_name" {
+  description = "Cognito User Poolの名前"
+  type        = string
+}
+
+variable "username_attributes" {
+  description = "ユーザー名として使用する属性（email, phone_number, または両方）"
+  type        = list(string)
+  default     = ["email"]
+
+  validation {
+    condition = alltrue([
+      for attr in var.username_attributes : contains(["email", "phone_number"], attr)
+    ])
+    error_message = "username_attributesには'email'または'phone_number'のみを指定できます。"
+  }
+}
+
+variable "username_case_sensitive" {
+  description = "ユーザー名の大文字小文字を区別するか"
+  type        = bool
+  default     = false
+}
+
+variable "auto_verified_attributes" {
+  description = "自動検証する属性（email, phone_number）"
+  type        = list(string)
+  default     = ["email"]
+
+  validation {
+    condition = alltrue([
+      for attr in var.auto_verified_attributes : contains(["email", "phone_number"], attr)
+    ])
+    error_message = "auto_verified_attributesには'email'または'phone_number'のみを指定できます。"
+  }
+}
+
+variable "mfa_configuration" {
+  description = "MFA設定（OFF, OPTIONAL, ON）"
+  type        = string
+  default     = "OPTIONAL"
+
+  validation {
+    condition     = contains(["OFF", "OPTIONAL", "ON"], var.mfa_configuration)
+    error_message = "mfa_configurationは'OFF', 'OPTIONAL', 'ON'のいずれかである必要があります。"
+  }
+}
+
+#######################################################
+# Password Policy
+#######################################################
+
+variable "password_policy" {
+  description = "パスワードポリシーの設定"
+  type = object({
+    minimum_length                   = number
+    require_lowercase                = bool
+    require_uppercase                = bool
+    require_numbers                  = bool
+    require_symbols                  = bool
+    temporary_password_validity_days = number
+  })
+  default = {
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_uppercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    temporary_password_validity_days = 7
+  }
+
+  validation {
+    condition     = var.password_policy.minimum_length >= 6 && var.password_policy.minimum_length <= 99
+    error_message = "minimum_lengthは6以上99以下である必要があります。"
+  }
+
+  validation {
+    condition     = var.password_policy.temporary_password_validity_days >= 0 && var.password_policy.temporary_password_validity_days <= 365
+    error_message = "temporary_password_validity_daysは0以上365以下である必要があります。"
+  }
+}
+
+#######################################################
+# Account Recovery
+#######################################################
+
+variable "account_recovery_mechanism" {
+  description = "アカウント回復メカニズム"
+  type = object({
+    name     = string
+    priority = number
+  })
+  default = {
+    name     = "verified_email"
+    priority = 1
+  }
+
+  validation {
+    condition     = contains(["verified_email", "verified_phone_number", "admin_only"], var.account_recovery_mechanism.name)
+    error_message = "nameは'verified_email', 'verified_phone_number', 'admin_only'のいずれかである必要があります。"
+  }
+}
+
+#######################################################
+# Email Configuration
+#######################################################
+
+variable "email_configuration" {
+  description = "メール設定"
+  type = object({
+    email_sending_account = string
+  })
+  default = {
+    email_sending_account = "COGNITO_DEFAULT"
+  }
+
+  validation {
+    condition     = contains(["COGNITO_DEFAULT", "DEVELOPER"], var.email_configuration.email_sending_account)
+    error_message = "email_sending_accountは'COGNITO_DEFAULT'または'DEVELOPER'である必要があります。"
+  }
+}
+
+#######################################################
+# Device Configuration
+#######################################################
+
+variable "device_configuration" {
+  description = "デバイス記憶設定"
+  type = object({
+    challenge_required_on_new_device      = bool
+    device_only_remembered_on_user_prompt = bool
+  })
+  default = {
+    challenge_required_on_new_device      = false
+    device_only_remembered_on_user_prompt = true
+  }
+}
+
+#######################################################
+# Schema
+#######################################################
+
+variable "schemas" {
+  description = "ユーザー属性のスキーマ定義"
+  type = list(object({
+    name                     = string
+    attribute_data_type      = string
+    developer_only_attribute = optional(bool, false)
+    mutable                  = optional(bool, true)
+    required                 = optional(bool, false)
+    min_length               = optional(number, 0)
+    max_length               = optional(number, 2048)
+    min_value                = optional(number)
+    max_value                = optional(number)
+  }))
+  default = []
+}
+
+#######################################################
+# App Client Configuration
+#######################################################
+
+variable "app_client_name" {
+  description = "App Clientの名前"
+  type        = string
+}
+
+variable "oauth_flows" {
+  description = "許可するOAuthフロー（code, implicit, client_credentials）"
+  type        = list(string)
+  default     = ["code"]
+
+  validation {
+    condition = alltrue([
+      for flow in var.oauth_flows : contains(["code", "implicit", "client_credentials"], flow)
+    ])
+    error_message = "oauth_flowsには'code', 'implicit', 'client_credentials'のみを指定できます。"
+  }
+}
+
+variable "oauth_flows_enabled" {
+  description = "OAuthフローを有効にするか"
+  type        = bool
+  default     = true
+}
+
+variable "oauth_scopes" {
+  description = "許可するOAuthスコープ"
+  type        = list(string)
+  default     = ["openid", "email", "profile"]
+}
+
+variable "callback_urls" {
+  description = "コールバックURL"
+  type        = list(string)
+  default     = []
+}
+
+variable "logout_urls" {
+  description = "ログアウトURL"
+  type        = list(string)
+  default     = []
+}
+
+variable "explicit_auth_flows" {
+  description = "サポートする認証フロー"
+  type        = list(string)
+  default = [
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_USER_PASSWORD_AUTH"
+  ]
+}
+
+variable "token_validity" {
+  description = "トークンの有効期限"
+  type = object({
+    refresh_token_validity = number
+    access_token_validity  = number
+    id_token_validity      = number
+  })
+  default = {
+    refresh_token_validity = 30
+    access_token_validity  = 60
+    id_token_validity      = 60
+  }
+}
+
+variable "token_validity_units" {
+  description = "トークン有効期限の単位"
+  type = object({
+    refresh_token = string
+    access_token  = string
+    id_token      = string
+  })
+  default = {
+    refresh_token = "days"
+    access_token  = "minutes"
+    id_token      = "minutes"
+  }
+
+  validation {
+    condition = alltrue([
+      contains(["seconds", "minutes", "hours", "days"], var.token_validity_units.refresh_token),
+      contains(["seconds", "minutes", "hours", "days"], var.token_validity_units.access_token),
+      contains(["seconds", "minutes", "hours", "days"], var.token_validity_units.id_token)
+    ])
+    error_message = "token_validity_unitsには'seconds', 'minutes', 'hours', 'days'のいずれかを指定できます。"
+  }
+}
+
+variable "generate_client_secret" {
+  description = "クライアントシークレットを生成するか"
+  type        = bool
+  default     = false
+}
+
+variable "enable_token_revocation" {
+  description = "トークン取り消しを有効にするか"
+  type        = bool
+  default     = true
+}
+
+variable "prevent_user_existence_errors" {
+  description = "ユーザー存在エラーを防ぐ設定（ENABLED, LEGACY）"
+  type        = string
+  default     = "ENABLED"
+
+  validation {
+    condition     = contains(["ENABLED", "LEGACY"], var.prevent_user_existence_errors)
+    error_message = "prevent_user_existence_errorsは'ENABLED'または'LEGACY'である必要があります。"
+  }
+}
+
+variable "enable_propagate_additional_user_context_data" {
+  description = "追加のユーザーコンテキストデータを伝播するか"
+  type        = bool
+  default     = false
+}
+
+variable "read_attributes" {
+  description = "読み取り可能な属性"
+  type        = list(string)
+  default     = []
+}
+
+variable "write_attributes" {
+  description = "書き込み可能な属性"
+  type        = list(string)
+  default     = []
+}
+
+variable "supported_identity_providers" {
+  description = "サポートする認証プロバイダー"
+  type        = list(string)
+  default     = ["COGNITO"]
+}
+
+#######################################################
+# User Pool Domain (Optional)
+#######################################################
+
+variable "domain" {
+  description = "Cognito User Pool Domain（空文字の場合は作成しない）"
+  type        = string
+  default     = ""
+}
+
+#######################################################
+# User Groups
+#######################################################
+
+variable "user_groups" {
+  description = "作成するユーザーグループのリスト"
+  type = list(object({
+    name        = string
+    description = optional(string)
+    precedence  = optional(number)
+    role_arn    = optional(string)
+  }))
+  default = []
+}
+
+#######################################################
+# Tags
+#######################################################
+
+variable "tags" {
+  description = "リソースに付与するタグ"
+  type        = map(string)
+  default     = {}
+}

--- a/app/infra/modules/cognito/versions.tf
+++ b/app/infra/modules/cognito/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## 概要

Issue #3 に基づき、Amazon Cognito User Pool を構築する Terraform モジュールを実装しました。

## 関連 Issue

Closes #3

## 変更内容

### 実装したリソース
- **Cognito User Pool**: ユーザー認証基盤
  - パスワードポリシー設定（最小長、文字種要件）
  - MFA設定（OPTIONAL/ON/OFF）
  - アカウント回復設定
  - ユーザー名属性設定（email/phone_number）
- **Cognito User Pool Client**: アプリケーションクライアント
  - OAuth 2.0 / OpenID Connect 対応
  - トークン有効期限設定
  - セキュリティ設定（トークン取り消し、ユーザー列挙攻撃防止）
- **Cognito User Pool Domain**: 認証UI用ドメイン（オプション）
- **Cognito User Groups**: ユーザーグループ管理（admin, user等）

### セキュリティ対策
- ✅ ユーザー列挙攻撃防止（`prevent_user_existence_errors = "ENABLED"`）
- ✅ トークン取り消し機能（`enable_token_revocation = true`）
- ✅ 強力なパスワードポリシー
- ✅ MFAサポート
- ✅ ライフサイクル保護（`prevent_destroy = true`）

### ファイル構成
```
app/infra/modules/cognito/
├── main.tf              # メインリソース定義
├── variables.tf         # 変数定義（詳細なバリデーション付き）
├── outputs.tf           # 出力定義
├── versions.tf          # Terraform/プロバイダーバージョン
├── README.md            # モジュール使用方法
└── examples/
    └── dev/
        └── main.tf      # 開発環境向けサンプル
```

## テスト方法

### 1. Terraform の検証

```bash
cd app/infra/modules/cognito/examples/dev
terraform init
terraform validate
terraform plan
```

### 2. 実際のリソース作成（任意）

```bash
terraform apply
```

### 3. User Pool の確認

```bash
# User Pool ID を確認
terraform output user_pool_id

# AWS CLI で User Pool を確認
aws cognito-idp describe-user-pool --user-pool-id <USER_POOL_ID>
```

## チェックリスト

- [x] Terraform コードを実装した
- [x] `terraform fmt` でフォーマットした
- [x] `terraform validate` で検証した
- [x] README を作成した
- [x] 開発環境向けのサンプルコードを作成した
- [x] セキュリティベストプラクティスを適用した
- [x] バリデーションルールを設定した
- [x] Issue #3 のタスクをすべて完了した

## 備考

- RDSモジュールの構成を参考に、一貫性のある構造で実装しました
- Context7 MCPを使用してAWS Cognito の最新ドキュメントを参照し、ベストプラクティスに従いました
- 本番環境向けの設定例は今後 `examples/prod/` に追加予定です

🤖 Generated with [Claude Code](https://claude.com/claude-code)